### PR TITLE
Added code to get the image urls from posts

### DIFF
--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"strings"
 	"time"
 )
 
@@ -16,6 +17,7 @@ type Post struct {
 	Content     string `json:"markdown"`
 	PublishedAt int64  `json:"published_at"`
 	Status      string `json:"status"`
+	Image       string `json:"image"`
 }
 
 type ExportData struct {
@@ -60,8 +62,14 @@ func main() {
 				fmt.Fprintf(w, "draft = %t\n", post.Status == "draft")
 				fmt.Fprintf(w, "title = \"%s\"\n", post.Title)
 				fmt.Fprintf(w, "slug = \"%s\"\n", post.Slug)
+				if post.Image != "" {
+					fmt.Fprintf(w, "image = \"%s\"\n", stripContentFolder(post.Image))
+				}
+				fmt.Fprintln(w, "aliases = [")
+				fmt.Fprintf(w, "\t\"%s\"\n", post.Slug)
+				fmt.Fprintln(w, "]")
 				fmt.Fprintln(w, "+++")
-				fmt.Fprint(w, post.Content)
+				fmt.Fprint(w, stripContentFolder(post.Content))
 				w.Flush()
 				done <- true
 			}(post)
@@ -71,4 +79,8 @@ func main() {
 			<-done
 		}
 	}
+}
+
+func stripContentFolder(originalString string) string {
+	return strings.Replace(originalString, "/content/", "/", -1)
 }


### PR DESCRIPTION
This adds a .Image property to the Post so it can be used by theme templates to add images per post to the resulting page. It also strips out the /content/ from image paths in the post so that you can take your images folder from Ghost and drop it into the Hugo static/ folder and the references should just work.