### PR TITLE
resolve nil description bug

### DIFF
--- a/ghosttohugo/card.go
+++ b/ghosttohugo/card.go
@@ -37,7 +37,7 @@ func cardBookmark(payload interface{}) string {
 		return ""
 	}
 	description, ok := metadata["description"]
-	if !ok {
+	if !ok || description == nil {
 		jww.ERROR.Println("cardBookmark: missing description")
 		return ""
 	}


### PR DESCRIPTION
i have found during an export that some card bookmarks don't have a description. This causes a panic, the following PR resolves the nil description problem.